### PR TITLE
Fixed usage only printing the first character of listed commands

### DIFF
--- a/n_utils/cli.py
+++ b/n_utils/cli.py
@@ -132,8 +132,8 @@ def ndt():
         if command not in COMMAND_MAPPINGS:
             sys.stderr.writelines([u'usage: ndt <command> [args...]\n'])
             sys.stderr.writelines([u'\tcommand shoud be one of:\n'])
-            for command in COMMAND_MAPPINGS:
-                sys.stderr.writelines([u'\t\t' + command[0] + '\n'])
+            for command in sorted(COMMAND_MAPPINGS):
+                sys.stderr.writelines([u'\t\t' + command + '\n'])
             sys.exit(1)
         command_type = COMMAND_MAPPINGS[command]
         if command_type == "shell":


### PR DESCRIPTION
The output before this fix was:
```
(ndt) (master) % ndt hekp                                                                                                                                                      ~/Projects/nitor/nitor-deploy-tools
usage: ndt <command> [args...]
	command shoud be one of:
		s
		e
		l
		c
		s
		l
		p
		e
		h
		c
		e
		a
		l
		j
		n
		d
		a
		n
		c
		l
		a
		d
		e
		y
		s
		l
		e
		c
		c
		e
		c
		s
		u
		s
		s
		c
		v
		a
		e
		s
		l
		s
		c
		s
		c
		l
		c
		b
```

And afterwards: 
```
usage: ndt <command> [args...]
	command shoud be one of:
		account-id
		add-deployer-server
		associate-eip
		assume-role
		bake-image
		cf-follow-logs
		cf-get-parameter
		cf-logical-id
		cf-logs-to-cloudwatch
		cf-region
		cf-signal-status
		cf-stack-id
		cf-stack-name
		create-shell-archive
		create-userid-list
		deploy-stack
		detach-volume
		ec2-associate-eip
		ec2-clean-snapshots
		ec2-get-userdata
		ec2-instance-id
		ec2-region
		encrypt-and-mount
		ensure-letsencrypt-certs
		hook
		json-to-yaml
		lastpass-fetch-notes
		lastpass-login
		lastpass-logout
		letsencrypt
		list-file-to-json
		logs-to-cloudwatch
		lpssh
		n-include
		n-utils-init
		pytail
		s3-role-download
		setup-cli
		setup-fetch-secrets
		setup-networks
		show-stack-params-and-outputs
		signal-cf-status
		snapshot-from-volume
		source_infra_properties
		ssh-hostkeys-collect
		undeploy-stack
		volume-from-snapshot
		yaml-to-json
```