### PR TITLE
Setup CI and unit testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,5 @@ ENV/
 # tmp files
 *~
 
+# Pytest
+.pytest_cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+cache: pip
 python:
   - "2.7"
   - "3.5"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: python
+python:
+  - "2.7"
+  - "3.5"
+  - "3.6"
+# command to install dependencies
+install:
+  - python setup.py install
+# command to run tests
+script:
+  - python setup.py test

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Nitor Deploy Tools
+[![Build Status](https://travis-ci.org/NitorCreations/nitor-deploy-tools.svg?branch=master)](https://travis-ci.org/NitorCreations/nitor-deploy-tools)
 
 ## Released version 1.0a31
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,5 @@
 # Nitor Deploy Tools
+[![Build Status](https://travis-ci.org/NitorCreations/nitor-deploy-tools.svg?branch=master)](https://travis-ci.org/NitorCreations/nitor-deploy-tools)
 
 ## Released version 0.223
 

--- a/n_utils/tests/account_utils_test.py
+++ b/n_utils/tests/account_utils_test.py
@@ -1,0 +1,9 @@
+from n_utils.account_utils import find_role_arn
+
+
+def test_find_role_arn(mocker):
+    boto3 = mocker.patch('n_utils.account_utils.boto3')
+
+    find_role_arn('foo')
+
+    boto3.client.assert_called_with('cloudformation')

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [metadata]
 description-file = README.md
+
+[aliases]
+test=pytest

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,9 @@ setup(name='nitor_deploy_tools',
       entry_points={
           'console_scripts': CONSOLESCRIPTS,
       },
+      setup_requires=[
+          'pytest-runner'
+      ],
       install_requires=[
           'pyaml',
           'boto3',
@@ -47,4 +50,8 @@ setup(name='nitor_deploy_tools',
           'wmi',
           'pypiwin32'
           ] if sys.platform.startswith('win') else []),
+      tests_require=[
+          'pytest',
+          'pytest-mock'
+      ],
       zip_safe=False)


### PR DESCRIPTION
- Setups `pytest` for running unittests. Included `pytest-mock` for convenient mocking.
- Setups Travis-CI to run unittests with Python versions 2.7, 3.5 and 3.6.
- Contains a single "dummy" unit test. More tests added in following PR's.

Locally tests can be run with `python setup.py test` or after installing pytest with just `pytest`.