### PR TITLE
Document dry run for deploy-stack

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -271,6 +271,7 @@ positional arguments:
   bake-job    If an ami-id is not given, the ami id is resolved by getting the latest
 
 optional arguments:
+  -d, --dryrun  dry-run - show only the change set without actually deploying it
   -h, --help  show this help message and exit
 ```
 

--- a/n_utils/includes/deploy-stack.sh
+++ b/n_utils/includes/deploy-stack.sh
@@ -71,6 +71,7 @@ usage() {
   echo "              ami that is tagged with the bake-job name"
   echo "" >&2
   echo "optional arguments:" >&2
+  echo "  -d, --dryrun  dry-run - show only the change set without actually deploying it" >&2
   echo "  -h, --help  show this help message and exit" >&2
   exit 1
 }


### PR DESCRIPTION
The -d option was not documented for the deploy-stack command